### PR TITLE
Tracing stunt-hack

### DIFF
--- a/ObjectTracking/.cargo/config
+++ b/ObjectTracking/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tracing_unstable"]

--- a/ObjectTracking/Cargo.lock
+++ b/ObjectTracking/Cargo.lock
@@ -10,6 +10,10 @@ dependencies = [
  "color-eyre",
  "float-ord",
  "opencv",
+ "tracing 0.1.29 (git+https://github.com/xd009642/tracing?branch=feature/valuable-integration)",
+ "tracing-core 0.1.21 (git+https://github.com/xd009642/tracing?branch=feature/valuable-integration)",
+ "tracing-subscriber 0.2.25 (git+https://github.com/xd009642/tracing?branch=feature/valuable-integration)",
+ "valuable",
 ]
 
 [[package]]
@@ -34,6 +38,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -79,6 +92,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "winapi",
+]
+
+[[package]]
 name = "clang"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +121,7 @@ checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
 dependencies = [
  "glob",
  "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -121,7 +147,7 @@ checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
 dependencies = [
  "once_cell",
  "owo-colors",
- "tracing-core",
+ "tracing-core 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-error",
 ]
 
@@ -166,6 +192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "jobserver"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,10 +219,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
+name = "libloading"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -206,6 +266,16 @@ checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -322,6 +392,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,10 +413,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
 name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
+name = "serde"
+version = "1.0.132"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+
+[[package]]
+name = "serde_json"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -353,6 +455,12 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "syn"
@@ -382,8 +490,19 @@ checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
+ "tracing-attributes 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.29"
+source = "git+https://github.com/xd009642/tracing?branch=feature/valuable-integration#9735ac521ae49a9e36a3d56f9d797db963f7ffc9"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes 0.1.18 (git+https://github.com/xd009642/tracing?branch=feature/valuable-integration)",
+ "tracing-core 0.1.21 (git+https://github.com/xd009642/tracing?branch=feature/valuable-integration)",
 ]
 
 [[package]]
@@ -391,6 +510,16 @@ name = "tracing-attributes"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.18"
+source = "git+https://github.com/xd009642/tracing?branch=feature/valuable-integration#9735ac521ae49a9e36a3d56f9d797db963f7ffc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -407,13 +536,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-core"
+version = "0.1.21"
+source = "git+https://github.com/xd009642/tracing?branch=feature/valuable-integration#9735ac521ae49a9e36a3d56f9d797db963f7ffc9"
+dependencies = [
+ "lazy_static",
+ "valuable",
+]
+
+[[package]]
 name = "tracing-error"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
 dependencies = [
- "tracing",
- "tracing-subscriber",
+ "tracing 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-subscriber 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "git+https://github.com/xd009642/tracing?branch=feature/valuable-integration#9735ac521ae49a9e36a3d56f9d797db963f7ffc9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core 0.1.21 (git+https://github.com/xd009642/tracing?branch=feature/valuable-integration)",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "git+https://github.com/xd009642/tracing?branch=feature/valuable-integration#9735ac521ae49a9e36a3d56f9d797db963f7ffc9"
+dependencies = [
+ "serde",
+ "tracing-core 0.1.21 (git+https://github.com/xd009642/tracing?branch=feature/valuable-integration)",
 ]
 
 [[package]]
@@ -424,7 +581,28 @@ checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
  "sharded-slab",
  "thread_local",
- "tracing-core",
+ "tracing-core 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "git+https://github.com/xd009642/tracing?branch=feature/valuable-integration#9735ac521ae49a9e36a3d56f9d797db963f7ffc9"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing 0.1.29 (git+https://github.com/xd009642/tracing?branch=feature/valuable-integration)",
+ "tracing-core 0.1.21 (git+https://github.com/xd009642/tracing?branch=feature/valuable-integration)",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -434,7 +612,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "git+https://github.com/tokio-rs/valuable#c21c67ea2c288e687dfb2282b4c5d330dd2f3161"
+dependencies = [
+ "valuable-derive",
+]
+
+[[package]]
+name = "valuable-derive"
+version = "0.1.0"
+source = "git+https://github.com/tokio-rs/valuable#c21c67ea2c288e687dfb2282b4c5d330dd2f3161"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/ObjectTracking/Cargo.lock
+++ b/ObjectTracking/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "anyhow",
  "color-eyre",
  "float-ord",
+ "mjpeg_rs",
  "opencv",
  "tracing 0.1.29 (git+https://github.com/xd009642/tracing?branch=feature/valuable-integration)",
  "tracing-subscriber 0.2.25 (git+https://github.com/xd009642/tracing?branch=feature/valuable-integration)",
@@ -266,6 +267,12 @@ dependencies = [
  "adler",
  "autocfg",
 ]
+
+[[package]]
+name = "mjpeg_rs"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0286c84e99db6b13889a4e5a982f20014c26c5ae6fb9881208774e071cc4ecc7"
 
 [[package]]
 name = "num-integer"

--- a/ObjectTracking/Cargo.lock
+++ b/ObjectTracking/Cargo.lock
@@ -11,7 +11,6 @@ dependencies = [
  "float-ord",
  "opencv",
  "tracing 0.1.29 (git+https://github.com/xd009642/tracing?branch=feature/valuable-integration)",
- "tracing-core 0.1.21 (git+https://github.com/xd009642/tracing?branch=feature/valuable-integration)",
  "tracing-subscriber 0.2.25 (git+https://github.com/xd009642/tracing?branch=feature/valuable-integration)",
  "valuable",
 ]

--- a/ObjectTracking/Cargo.lock
+++ b/ObjectTracking/Cargo.lock
@@ -152,6 +152,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,8 +291,10 @@ dependencies = [
 [[package]]
 name = "mjpeg_rs"
 version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0286c84e99db6b13889a4e5a982f20014c26c5ae6fb9881208774e071cc4ecc7"
+source = "git+https://github.com/alsuren/mjpeg_rs?branch=backpressure#45fb62cd3caa7c4015f32b98395f2a58a88d798d"
+dependencies = [
+ "crossbeam-channel",
+]
 
 [[package]]
 name = "num-integer"

--- a/ObjectTracking/Cargo.toml
+++ b/ObjectTracking/Cargo.toml
@@ -9,8 +9,16 @@ edition = "2021"
 anyhow = "1.0.51"
 color-eyre = "0.5.11"
 float-ord = "0.3.2"
-opencv = { version = "0.61", features = ["highgui", "ximgproc"] }
+opencv = { version = "0.61", features = ["highgui", "ximgproc", "clang-runtime"] }
+tracing = { git = "https://github.com/xd009642/tracing", branch = "feature/valuable-integration", features = ["valuable"] }
+tracing-core = { git = "https://github.com/xd009642/tracing", branch = "feature/valuable-integration", features = ["valuable"] }
+tracing-subscriber = { git = "https://github.com/xd009642/tracing", branch = "feature/valuable-integration" }
+valuable = { git = "https://github.com/tokio-rs/valuable", features = ["derive"] }
 
 [[bin]]
 name = "basic_control_1d"
 path = "src/bin/basic_control_1d.rs"
+
+[[bin]]
+name = "test_track"
+path = "src/bin/test_track.rs"

--- a/ObjectTracking/Cargo.toml
+++ b/ObjectTracking/Cargo.toml
@@ -11,7 +11,6 @@ color-eyre = "0.5.11"
 float-ord = "0.3.2"
 opencv = { version = "0.61", features = ["highgui", "ximgproc", "clang-runtime"] }
 tracing = { git = "https://github.com/xd009642/tracing", branch = "feature/valuable-integration", features = ["valuable"] }
-tracing-core = { git = "https://github.com/xd009642/tracing", branch = "feature/valuable-integration", features = ["valuable"] }
 tracing-subscriber = { git = "https://github.com/xd009642/tracing", branch = "feature/valuable-integration" }
 valuable = { git = "https://github.com/tokio-rs/valuable", features = ["derive"] }
 

--- a/ObjectTracking/Cargo.toml
+++ b/ObjectTracking/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1.0.51"
 color-eyre = "0.5.11"
 float-ord = "0.3.2"
-opencv = { version = "0.61", features = ["highgui", "ximgproc", "clang-runtime"] }
+opencv = { version = "0.61", features = ["imgcodecs", "highgui", "ximgproc", "clang-runtime"] }
 tracing = { git = "https://github.com/xd009642/tracing", branch = "feature/valuable-integration", features = ["valuable"] }
 tracing-subscriber = { git = "https://github.com/xd009642/tracing", branch = "feature/valuable-integration" }
 valuable = { git = "https://github.com/tokio-rs/valuable", features = ["derive"] }

--- a/ObjectTracking/Cargo.toml
+++ b/ObjectTracking/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 anyhow = "1.0.51"
 color-eyre = "0.5.11"
 float-ord = "0.3.2"
+mjpeg_rs = "0.0.1"
 opencv = { version = "0.61", features = ["imgcodecs", "highgui", "ximgproc", "clang-runtime"] }
 tracing = { git = "https://github.com/xd009642/tracing", branch = "feature/valuable-integration", features = ["valuable"] }
 tracing-subscriber = { git = "https://github.com/xd009642/tracing", branch = "feature/valuable-integration" }

--- a/ObjectTracking/Cargo.toml
+++ b/ObjectTracking/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1.0.51"
 color-eyre = "0.5.11"
 float-ord = "0.3.2"
-mjpeg_rs = "0.0.1"
+mjpeg_rs = { git = "https://github.com/alsuren/mjpeg_rs", branch = "backpressure" }
 opencv = { version = "0.61", features = ["imgcodecs", "highgui", "ximgproc", "clang-runtime"] }
 tracing = { git = "https://github.com/xd009642/tracing", branch = "feature/valuable-integration", features = ["valuable"] }
 tracing-subscriber = { git = "https://github.com/xd009642/tracing", branch = "feature/valuable-integration" }

--- a/ObjectTracking/src/bin/basic_control_1d.rs
+++ b/ObjectTracking/src/bin/basic_control_1d.rs
@@ -219,7 +219,7 @@ impl tracing::Subscriber for MJpegTracingSubscriber {
     // If the mjpeg server is behind, disable subscription for a bit
     fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
         match self.visitor.try_lock() {
-            Ok(_) => true,
+            Ok(visitor) => !visitor.mjpeg_server.is_full(),
             _ => false,
         }
     }

--- a/ObjectTracking/src/bin/basic_control_1d.rs
+++ b/ObjectTracking/src/bin/basic_control_1d.rs
@@ -12,8 +12,8 @@ use opencv::features2d::{self, SimpleBlobDetector, SimpleBlobDetector_Params};
 use opencv::imgproc::MORPH_CLOSE;
 use opencv::prelude::*;
 use opencv::{highgui, imgproc, videoio};
+use tracing::field::valuable;
 use tracing::{info, warn};
-use tracing_core::field::valuable;
 
 // import serial
 trait MatExt {

--- a/ObjectTracking/src/bin/basic_control_1d.rs
+++ b/ObjectTracking/src/bin/basic_control_1d.rs
@@ -1,20 +1,19 @@
 // import time
-use std::io::Write;
-use std::ops::Div;
 use std::thread::sleep;
 use std::time::Duration;
 
 // from SimpleCV import *
 use color_eyre::eyre;
 use opencv::core::{
-    abs_matexpr, min, no_array, sub_scalar_mat, KeyPoint, MatExpr, Point, Scalar, Size,
-    ToInputArray, Vector, _InputArrayTraitConst, mix_channels, split, BorderTypes, CV_32FC3,
-    CV_8UC3,
+    abs_matexpr, min, no_array, sub_scalar_mat, KeyPoint, Point, Scalar, Size, ToInputArray,
+    Vector, _InputArrayTraitConst, mix_channels, BorderTypes, CV_32FC3, CV_8UC3,
 };
 use opencv::features2d::{self, SimpleBlobDetector, SimpleBlobDetector_Params};
 use opencv::imgproc::MORPH_CLOSE;
 use opencv::prelude::*;
 use opencv::{highgui, imgproc, videoio};
+use tracing::{info, warn};
+use tracing_core::field::valuable;
 
 // import serial
 trait MatExt {
@@ -172,8 +171,21 @@ impl<T: ToInputArray> ToInputArrayExt for T {
     }
 }
 
+struct BGRImage(Mat);
+
+impl valuable::Valuable for BGRImage {
+    fn as_value(&self) -> valuable::Value<'_> {
+        todo!()
+    }
+
+    fn visit(&self, visit: &mut dyn valuable::Visit) {
+        todo!()
+    }
+}
+
 fn main() -> eyre::Result<()> {
     color_eyre::install()?;
+    tracing_subscriber::fmt::init();
 
     // cam = JpegStreamCamera('http://192.168.1.6:8080/videofeed')
     let mut cam = videoio::VideoCapture::new(0, videoio::CAP_ANY)?;
@@ -229,8 +241,10 @@ fn main() -> eyre::Result<()> {
             println!("{}", (z - 200.0) * 0.03);
             previous_z = z;
         }
+        warn!("hi there");
+        warn!(disk_img = valuable(BGRImage(disk_img.clone())));
         highgui::imshow(window, &disk_img)?;
-        if highgui::wait_key(10)? > 0 {
+        if highgui::wait_key(10)? > 0 || true {
             break;
         }
     }


### PR DESCRIPTION
This is a proof-of-concept that you **can** use `tracing` to debug jpeg images. There are a bunch of outstanding questions before we can answer whether we **should** use `tracing` for this. I will write it up properly tomorrow/next year.

The original idea for this comes from this talk by @xd009642: https://www.youtube.com/watch?v=mAg7_9e9454

Steps to reproduce:

```bash
export DYLD_FALLBACK_LIBRARY_PATH="$(xcode-select --print-path)/usr/lib/",
cargo run
open http://0.0.0.0:8088/
```

![Screenshot 2021-12-31 at 00 02 21](https://user-images.githubusercontent.com/254647/147795555-4bde71f4-2c1d-4501-8314-cc7b847a9b1e.png)

* We always encode the first jpeg, but that is enough to fill up the queue, so we stop subscribing after that.
* When you open the window, we start encoding jpegs.
* When you close the window, the queue backs up and we stop encoding jpegs, but we keep doing computer-vision stuff.

(don't worry about the panic that happens when you close the window. That's in the mjpeg_rs library, and should be easy to fix, but is harmless)

If you have any high-level thoughts on this, even if you have never met me or thought about debugging computer vision code before, please share them here. Probably best to make comments in the source-code view, so we can keep different trains of thought in different threads.